### PR TITLE
Fix comment body truncation to prevent GitHub API error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -556,8 +556,8 @@ class OidcClient {
             const res = yield httpclient
                 .getJson(id_token_url)
                 .catch(error => {
-                throw new Error(`Failed to get ID Token. \n
-        Error Code : ${error.statusCode}\n
+                throw new Error(`Failed to get ID Token. \n 
+        Error Code : ${error.statusCode}\n 
         Error Message: ${error.result.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
@@ -11244,7 +11244,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /************************************************************************/
 /******/ 	// The module cache
 /******/ 	var __webpack_module_cache__ = {};
-/******/
+/******/ 	
 /******/ 	// The require function
 /******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
@@ -11258,7 +11258,7 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
-/******/
+/******/ 	
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
@@ -11267,16 +11267,16 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
 /******/ 		}
-/******/
+/******/ 	
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/
+/******/ 	
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
-/******/
+/******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-/******/
+/******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.

--- a/dist/index.js
+++ b/dist/index.js
@@ -11390,6 +11390,14 @@ async function run() {
   }
   commentBody += '\n' + commentMark + '\n';
 
+  // Truncate comment body if it exceeds GitHub's limit
+  const MAX_COMMENT_LENGTH = 65536;
+  if (commentBody.length > MAX_COMMENT_LENGTH) {
+    const truncationMessage = '\n\n⚠️ **Note:** This coverage report has been truncated due to GitHub comment size limits. Full report available in the GitHub Action logs.';
+    const availableLength = MAX_COMMENT_LENGTH - truncationMessage.length;
+    commentBody = commentBody.substring(0, availableLength) + truncationMessage;
+  }
+
   const commentMode = core.getInput(ActionInput.comment_mode);
 
   const octokit = await github.getOctokit(gitHubToken);

--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,14 @@ async function run() {
   }
   commentBody += '\n' + commentMark + '\n';
 
+  // Truncate comment body if it exceeds GitHub's limit
+  const MAX_COMMENT_LENGTH = 65536;
+  if (commentBody.length > MAX_COMMENT_LENGTH) {
+    const truncationMessage = '\n\n⚠️ **Note:** This coverage report has been truncated due to GitHub comment size limits. Full report available in the GitHub Action logs.';
+    const availableLength = MAX_COMMENT_LENGTH - truncationMessage.length;
+    commentBody = commentBody.substring(0, availableLength) + truncationMessage;
+  }
+
   const commentMode = core.getInput(ActionInput.comment_mode);
 
   const octokit = await github.getOctokit(gitHubToken);


### PR DESCRIPTION
Summary
Adds validation and truncation logic to prevent "Body is too long" GitHub API errors
Truncates comment body when it exceeds GitHub's 65,536 character limit
Includes helpful message informing users that the report was truncated and directs them to action logs for full report
Test plan
 Test with large coverage reports that would exceed character limit
 Verify truncation message appears correctly
 Confirm GitHub API calls succeed after truncation
🤖 Generated with [Claude Code](https://claude.ai/code)